### PR TITLE
/tags/delete_tags_with_no_entities endpoint

### DIFF
--- a/app/api/v1/entity_tags/controller.py
+++ b/app/api/v1/entity_tags/controller.py
@@ -24,7 +24,7 @@ from app.common.base_entity.model import (
     SuccessItem,
 )
 from app.common.database import get_db
-from app.api.v1.entity_tags.model import (
+from app.api.v1.entity_tags.types import (
     EntityTagResponse,
     EntityTagCreateRequest,
     EntityTag,

--- a/app/api/v1/entity_tags/model.py
+++ b/app/api/v1/entity_tags/model.py
@@ -1,10 +1,7 @@
 """
-This module contains the ORM model and DTO models related to the EntityTag entity
+This module contains the ORM model for EntityTag entity
 """
 
-from typing import Optional
-
-from pydantic import BaseModel
 from sqlalchemy import (
     Column,
     Integer,
@@ -13,9 +10,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
 )
 
-from app.api.v1.tag_groups.service import TagGroupService
-from app.api.v1.tags.model import TagResponse
-from app.api.v1.tags.service import TagService
+
 from app.common.database import Base
 
 
@@ -32,67 +27,3 @@ class EntityTag(Base):
     __table_args__ = (
         PrimaryKeyConstraint("entity_id", "tag_id", name="pk_entity_tags"),
     )
-
-
-class EntityTagCreateRequest(BaseModel):
-    entity_id: str
-    entity_type: str
-    tag_id: int
-
-
-class EntityTagDeleteRequest(BaseModel):
-    entity_id: str
-    tag_id: Optional[int] = None
-
-
-class TagGroupTagsByNameRequest(BaseModel):
-    tag_group_name: str
-    tag_names: list[str]
-
-
-class ResetEntityTagsByNameRequest(BaseModel):
-    entity_id: str
-    entity_type: str
-    tag_groups: list[TagGroupTagsByNameRequest]
-
-
-class ResetEntityTagsByNameResponse(BaseModel):
-    entity_id: str
-    entity_type: str
-    tags: list[TagResponse]
-    errors: list[str] = []
-
-
-class EntityTagResponse(BaseModel):
-    """Structure of the EntityTag entity to be returned in the API response (DTO)"""
-
-    entity_id: str
-    entity_type: str
-    tag_id: int
-    tag: TagResponse
-
-    @classmethod
-    def from_entity_tag(
-        cls,
-        entity_tag: EntityTag,
-        tag_service: TagService,
-        tag_group_service: TagGroupService,
-    ):
-        tag = tag_service.get(entity_tag.tag_id)
-
-        return cls(
-            entity_id=entity_tag.entity_id,
-            entity_type=entity_tag.entity_type,
-            tag_id=entity_tag.tag_id,
-            tag=TagResponse.from_tag(tag, tag_group_service),
-            # create_date=entity_tag.create_date,
-        )
-
-
-# Define a generic type variable
-# T = TypeVar("T")
-#
-#
-# class BulkOperationResult(BaseModel, Generic[T]):
-#     results: List[T]
-#     errors: List[str]

--- a/app/api/v1/entity_tags/service.py
+++ b/app/api/v1/entity_tags/service.py
@@ -4,7 +4,7 @@ It uses the repository layer to interact with the database.
 """
 
 from typing import List
-from app.api.v1.entity_tags.model import (
+from app.api.v1.entity_tags.types import (
     EntityTag,
     EntityTagCreateRequest,
     EntityTagDeleteRequest,
@@ -63,9 +63,7 @@ class EntityTagService:
         logger.debug(f"Resetting tags for entity {request.entity_id}")
 
         logger.debug(f"Deleting existing tags for entity: {request.entity_id}")
-        deleted = self.delete(
-            EntityTagDeleteRequest(entity_id=request.entity_id)
-        )
+        deleted = self.delete(EntityTagDeleteRequest(entity_id=request.entity_id))
         logger.debug(f"Deleted {deleted} tags for entity: {request.entity_id}")
 
         for tag_group_req in request.tag_groups:

--- a/app/api/v1/entity_tags/types.py
+++ b/app/api/v1/entity_tags/types.py
@@ -1,0 +1,65 @@
+"""
+This module contains DTO models related to the EntityTag entity
+"""
+from pydantic import BaseModel
+
+from app.api.v1.entity_tags.model import EntityTag
+from app.api.v1.tag_groups.service import TagGroupService
+from app.api.v1.tags.model import TagResponse
+from app.api.v1.tags.service import TagService
+from typing import Optional
+
+
+class EntityTagCreateRequest(BaseModel):
+    entity_id: str
+    entity_type: str
+    tag_id: int
+
+
+class EntityTagDeleteRequest(BaseModel):
+    entity_id: str
+    tag_id: Optional[int] = None
+
+
+class TagGroupTagsByNameRequest(BaseModel):
+    tag_group_name: str
+    tag_names: list[str]
+
+
+class ResetEntityTagsByNameRequest(BaseModel):
+    entity_id: str
+    entity_type: str
+    tag_groups: list[TagGroupTagsByNameRequest]
+
+
+class ResetEntityTagsByNameResponse(BaseModel):
+    entity_id: str
+    entity_type: str
+    tags: list[TagResponse]
+    errors: list[str] = []
+
+
+class EntityTagResponse(BaseModel):
+    """Structure of the EntityTag entity to be returned in the API response (DTO)"""
+
+    entity_id: str
+    entity_type: str
+    tag_id: int
+    tag: TagResponse
+
+    @classmethod
+    def from_entity_tag(
+        cls,
+        entity_tag: EntityTag,
+        tag_service: TagService,
+        tag_group_service: TagGroupService,
+    ):
+        tag = tag_service.get(entity_tag.tag_id)
+
+        return cls(
+            entity_id=entity_tag.entity_id,
+            entity_type=entity_tag.entity_type,
+            tag_id=entity_tag.tag_id,
+            tag=TagResponse.from_tag(tag, tag_group_service),
+            # create_date=entity_tag.create_date,
+        )

--- a/app/api/v1/tags/repository.py
+++ b/app/api/v1/tags/repository.py
@@ -3,8 +3,13 @@ This module contains the repository layer (database operations) for the Tags ent
 """
 
 from sqlalchemy.orm import Session
+
+from app.api.v1.entity_tags.model import EntityTag
 from app.api.v1.tags.model import Tag
 from app.common.base_entity.repository import BaseRepository
+from app.common.utils.logging_utils import get_logger
+
+logger = get_logger()
 
 
 class TagRepository(BaseRepository[Tag]):
@@ -14,3 +19,24 @@ class TagRepository(BaseRepository[Tag]):
 
     def __init__(self, db: Session):
         super().__init__(db, Tag)
+
+    def delete_tags_with_no_entities(self) -> int:
+        ghost_tags = (
+            self.db.query(Tag)
+            .outerjoin(EntityTag, Tag.id == EntityTag.tag_id)
+            # pylint: disable=singleton-comparison
+            .filter(EntityTag.entity_id == None)  # noqa: E711
+            .all()
+        )
+
+        ghost_tag_ids = [tag.id for tag in ghost_tags]
+        logger.debug(
+            f"Deleting {len(ghost_tags)} tags with no entities: {ghost_tag_ids}"
+        )
+
+        count = len(ghost_tags)
+        for tag in ghost_tags:
+            logger.debug(f"Deleting tag {tag}")
+            self.db.delete(tag)
+        self.db.commit()
+        return count

--- a/app/api/v1/tags/service.py
+++ b/app/api/v1/tags/service.py
@@ -5,11 +5,15 @@ It uses the repository layer to interact with the database.
 
 from typing import Optional
 
+from sqlalchemy.orm import Session
+
 from app.api.v1.tag_groups.model import TagGroup
 from app.api.v1.tags.model import Tag, TagCreateRequest
 from app.api.v1.tags.repository import TagRepository
 from app.common.base_entity.model import AdvancedSearchRequest, AdvancedSearchResponse
+from app.common.database import get_db
 from app.common.utils.logging_utils import get_logger
+from fastapi import Depends
 
 logger = get_logger()
 
@@ -60,3 +64,11 @@ class TagService:
             raise ValueError(f"Tag {name} already exists in another group")
 
         return tag
+
+    def delete_tags_with_no_entities(self) -> int:
+        return self.repository.delete_tags_with_no_entities()
+
+
+def get_tag_service(db: Session = Depends(get_db)) -> TagService:
+    repository = TagRepository(db)
+    return TagService(repository)

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -35,6 +35,7 @@ _settings = Dynaconf(
 # Debugging: Print environment variables
 logger.debug(f"Environment Variables: {os.environ}")
 
+
 class Settings:
     """
     This class is a WA for the fact that Dynaconf does not seem to let env variables

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,7 +1,8 @@
-'''
+"""
 This file is run when we execute alembic (db schema migration) commands,
 from command line and programatically.
-'''
+"""
+
 import sys
 import os
 from alembic import context


### PR DESCRIPTION
… tag deletion

- Moved DTO classes related to entity tags from `model.py` to a new `types.py` module for better organization.
- Added functionality to delete tags with no associated entities in the `TagRepository` and exposed it via a new API endpoint.
- Updated imports and dependencies across modules to reflect these changes.